### PR TITLE
Add minus bug

### DIFF
--- a/src/org/bds/Bds.java
+++ b/src/org/bds/Bds.java
@@ -13,7 +13,7 @@ import org.bds.util.Gpr;
 public class Bds implements BdsLog {
 
     public static final String BUILD = Gpr.compileTimeStamp(Bds.class);
-    public static final String REVISION = "a";
+    public static final String REVISION = "b";
     public static final String SOFTWARE_NAME = "bds";
     public static final String VERSION_MAJOR = "3.4";
     public static final String VERSION_SHORT = VERSION_MAJOR + REVISION;

--- a/src/org/bds/lang/BdsNode.java
+++ b/src/org/bds/lang/BdsNode.java
@@ -424,7 +424,7 @@ public abstract class BdsNode implements Serializable, BdsLog {
         }
     }
 
-//    public Type returnType(SymbolTable symtab) {
+//    public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 //        return returnType(symtab, null);
 //    }
 

--- a/src/org/bds/lang/BdsNode.java
+++ b/src/org/bds/lang/BdsNode.java
@@ -1,12 +1,5 @@
 package org.bds.lang;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.Serializable;
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Set;
-
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
@@ -15,15 +8,17 @@ import org.bds.compile.BdsNodeWalker;
 import org.bds.compile.CompilerMessage.MessageType;
 import org.bds.compile.CompilerMessages;
 import org.bds.compile.TypeCheckedNodes;
-import org.bds.lang.type.PrimitiveType;
-import org.bds.lang.type.Type;
-import org.bds.lang.type.TypeList;
-import org.bds.lang.type.TypeMap;
-import org.bds.lang.type.Types;
+import org.bds.lang.type.*;
 import org.bds.run.BdsThread;
 import org.bds.symbol.SymbolTable;
 import org.bds.util.Gpr;
-import org.bds.util.Timer;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Base AST node (Abstract Syntax Tree) for bds language elements
@@ -219,8 +214,16 @@ public abstract class BdsNode implements Serializable, BdsLog {
         return lineNum;
     }
 
+    public void setLineNum(int lineNum) {
+        this.lineNum = lineNum;
+    }
+
     public BdsNode getParent() {
         return parent;
+    }
+
+    public void setParent(BdsNode parent) {
+        this.parent = parent;
     }
 
     /**
@@ -245,6 +248,10 @@ public abstract class BdsNode implements Serializable, BdsLog {
 
     public SymbolTable getSymbolTable() {
         return null;
+    }
+
+    public void setSymbolTable(SymbolTable symtab) {
+        compileError("Cannot set symbol table to node");
     }
 
     /**
@@ -319,6 +326,10 @@ public abstract class BdsNode implements Serializable, BdsLog {
      */
     public boolean isNeedsScope() {
         return false;
+    }
+
+    public void setNeedsScope(boolean needsScope) {
+        compileError("Cannot set 'needsScope'");
     }
 
     public boolean isNull() {
@@ -413,10 +424,14 @@ public abstract class BdsNode implements Serializable, BdsLog {
         }
     }
 
+//    public Type returnType(SymbolTable symtab) {
+//        return returnType(symtab, null);
+//    }
+
     /**
      * Calculate return type and assign it to 'returnType' variable.
      */
-    public Type returnType(SymbolTable symtab) {
+    public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
         if (returnType != null) return returnType;
         returnType = Types.VOID;
         return returnType;
@@ -427,22 +442,6 @@ public abstract class BdsNode implements Serializable, BdsLog {
      */
     public void sanityCheck(CompilerMessages compilerMessages) {
         // Default : Do nothing
-    }
-
-    public void setLineNum(int lineNum) {
-        this.lineNum = lineNum;
-    }
-
-    public void setNeedsScope(boolean needsScope) {
-        compileError("Cannot set 'needsScope'");
-    }
-
-    public void setParent(BdsNode parent) {
-        this.parent = parent;
-    }
-
-    public void setSymbolTable(SymbolTable symtab) {
-        compileError("Cannot set symbol table to node");
     }
 
     public String toAsm() {
@@ -547,7 +546,7 @@ public abstract class BdsNode implements Serializable, BdsLog {
      */
     public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
         // Calculate return type
-        returnType = returnType(symtab);
+        returnType = returnType(symtab, compilerMessages);
 
         // Are return types non-null?
         // Note: null returnTypes happen if variables are missing.

--- a/src/org/bds/lang/ProgramUnit.java
+++ b/src/org/bds/lang/ProgramUnit.java
@@ -9,6 +9,7 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.bds.compile.BdsNodeWalker;
+import org.bds.compile.CompilerMessages;
 import org.bds.lang.statement.BlockWithFile;
 import org.bds.lang.statement.ClassDeclaration;
 import org.bds.lang.statement.FunctionDeclaration;
@@ -106,7 +107,7 @@ public class ProgramUnit extends BlockWithFile {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		return Types.INT;
 	}
 

--- a/src/org/bds/lang/expression/ExpressionAssignment.java
+++ b/src/org/bds/lang/expression/ExpressionAssignment.java
@@ -29,10 +29,10 @@ public class ExpressionAssignment extends ExpressionBinary {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		super.returnType(symtab);
+		super.returnType(symtab, compilerMessages);
 		returnType = left.getReturnType();
 
 		return returnType;

--- a/src/org/bds/lang/expression/ExpressionAssignmentBinary.java
+++ b/src/org/bds/lang/expression/ExpressionAssignmentBinary.java
@@ -1,6 +1,7 @@
 package org.bds.lang.expression;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.bds.compile.CompilerMessages;
 import org.bds.lang.BdsNode;
 import org.bds.lang.type.Type;
 import org.bds.symbol.SymbolTable;
@@ -52,7 +53,7 @@ public abstract class ExpressionAssignmentBinary extends ExpressionAssignment {
 	 * In some cases we need to replace the sub-expression after we know the left-hand side type
 	 * E.g.: '&=' uses BitAnd for int and LogicAnd for bool
 	 */
-	protected void replaceSubExpression(SymbolTable symtab) {
+	protected void replaceSubExpression(SymbolTable symtab, CompilerMessages compilerMessages) {
 		// Nothing to do
 	}
 
@@ -60,7 +61,7 @@ public abstract class ExpressionAssignmentBinary extends ExpressionAssignment {
 	 * Replace the sub-expression after we know the left-hand side type is 'bool'
 	 * E.g.: '&=' uses BitAnd for int and LogicAnd for bool
 	 */
-	protected void replaceSubExpressionBool(SymbolTable symtab) {
+	protected void replaceSubExpressionBool(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (!left.isBool()) return;
 
 		// Get original left and right expressions
@@ -71,17 +72,17 @@ public abstract class ExpressionAssignmentBinary extends ExpressionAssignment {
 		ExpressionBinary reb = createSubExpressionBool(left.getReturnType());
 		reb.setLeft(l);
 		reb.setRight(r);
-		reb.returnType(symtab);
+		reb.returnType(symtab, compilerMessages);
 		right = reb;
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		super.returnType(symtab);
+		super.returnType(symtab, compilerMessages);
 		returnType = left.getReturnType();
-		replaceSubExpression(symtab);
+		replaceSubExpression(symtab, compilerMessages);
 
 		return returnType;
 	}

--- a/src/org/bds/lang/expression/ExpressionAssignmentBitAnd.java
+++ b/src/org/bds/lang/expression/ExpressionAssignmentBitAnd.java
@@ -1,6 +1,7 @@
 package org.bds.lang.expression;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.bds.compile.CompilerMessages;
 import org.bds.lang.BdsNode;
 import org.bds.lang.type.Type;
 import org.bds.symbol.SymbolTable;
@@ -34,8 +35,8 @@ public class ExpressionAssignmentBitAnd extends ExpressionAssignmentBinary {
 	}
 
 	@Override
-	protected void replaceSubExpression(SymbolTable symtab) {
-		if (left.isBool()) replaceSubExpressionBool(symtab);
+	protected void replaceSubExpression(SymbolTable symtab, CompilerMessages compilerMessages) {
+		if (left.isBool()) replaceSubExpressionBool(symtab, compilerMessages);
 	}
 
 }

--- a/src/org/bds/lang/expression/ExpressionAssignmentBitOr.java
+++ b/src/org/bds/lang/expression/ExpressionAssignmentBitOr.java
@@ -1,6 +1,7 @@
 package org.bds.lang.expression;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.bds.compile.CompilerMessages;
 import org.bds.lang.BdsNode;
 import org.bds.lang.type.Type;
 import org.bds.symbol.SymbolTable;
@@ -34,7 +35,7 @@ public class ExpressionAssignmentBitOr extends ExpressionAssignmentBinary {
 	}
 
 	@Override
-	protected void replaceSubExpression(SymbolTable symtab) {
-		if (left.isBool()) replaceSubExpressionBool(symtab);
+	protected void replaceSubExpression(SymbolTable symtab, CompilerMessages compilerMessages) {
+		if (left.isBool()) replaceSubExpressionBool(symtab, compilerMessages);
 	}
 }

--- a/src/org/bds/lang/expression/ExpressionAssignmentList.java
+++ b/src/org/bds/lang/expression/ExpressionAssignmentList.java
@@ -59,14 +59,14 @@ public class ExpressionAssignmentList extends ExpressionAssignment {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		for (Expression l : lefts)
-			l.returnType(symtab);
-		right.returnType(symtab);
+			l.returnType(symtab, compilerMessages);
+		right.returnType(symtab, compilerMessages);
 
-		returnType = lefts[0].returnType(symtab); // Get return type for first expression
+		returnType = lefts[0].returnType(symtab, compilerMessages); // Get return type for first expression
 		return returnType;
 	}
 

--- a/src/org/bds/lang/expression/ExpressionBinary.java
+++ b/src/org/bds/lang/expression/ExpressionBinary.java
@@ -1,6 +1,7 @@
 package org.bds.lang.expression;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.bds.compile.CompilerMessages;
 import org.bds.lang.BdsNode;
 import org.bds.lang.type.Type;
 import org.bds.symbol.SymbolTable;
@@ -50,11 +51,11 @@ public class ExpressionBinary extends Expression {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		if (left != null) returnType = left.returnType(symtab); // Left could be empty when there are some compile error (e.g. empty "switch" statement)
-		if (right != null) right.returnType(symtab); // Only assign this to show that calculation was already performed
+		if (left != null) returnType = left.returnType(symtab, compilerMessages); // Left could be empty when there are some compile error (e.g. empty "switch" statement)
+		if (right != null) right.returnType(symtab, compilerMessages); // Only assign this to show that calculation was already performed
 
 		return returnType;
 	}

--- a/src/org/bds/lang/expression/ExpressionBit.java
+++ b/src/org/bds/lang/expression/ExpressionBit.java
@@ -21,10 +21,10 @@ public class ExpressionBit extends ExpressionBinary {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		super.returnType(symtab);
+		super.returnType(symtab, compilerMessages);
 		returnType = Types.INT;
 
 		return returnType;

--- a/src/org/bds/lang/expression/ExpressionBitXor.java
+++ b/src/org/bds/lang/expression/ExpressionBitXor.java
@@ -26,10 +26,10 @@ public class ExpressionBitXor extends ExpressionBit {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		super.returnType(symtab);
+		super.returnType(symtab, compilerMessages);
 
 		if (left.isBool() && right.isBool()) returnType = Types.BOOL;
 		else returnType = Types.INT;

--- a/src/org/bds/lang/expression/ExpressionCast.java
+++ b/src/org/bds/lang/expression/ExpressionCast.java
@@ -34,11 +34,11 @@ public class ExpressionCast extends ExpressionUnary {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		returnType = Types.get(castTo);
-		expr.returnType(symtab);
+		expr.returnType(symtab, compilerMessages);
 		return returnType;
 	}
 
@@ -55,7 +55,7 @@ public class ExpressionCast extends ExpressionUnary {
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
 		// Calculate return type
-		returnType = returnType(symtab);
+		returnType = returnType(symtab, compilerMessages);
 
 		// Are return types non-null?
 		// Note: null returnTypes happen if variables are missing.

--- a/src/org/bds/lang/expression/ExpressionCompare.java
+++ b/src/org/bds/lang/expression/ExpressionCompare.java
@@ -22,10 +22,10 @@ public abstract class ExpressionCompare extends ExpressionBinary {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		super.returnType(symtab);
+		super.returnType(symtab, compilerMessages);
 		returnType = Types.BOOL;
 
 		return returnType;

--- a/src/org/bds/lang/expression/ExpressionCond.java
+++ b/src/org/bds/lang/expression/ExpressionCond.java
@@ -46,12 +46,12 @@ public class ExpressionCond extends Expression {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		expr.returnType(symtab);
-		returnType = exprTrue.returnType(symtab);
-		exprFalse.returnType(symtab);
+		expr.returnType(symtab, compilerMessages);
+		returnType = exprTrue.returnType(symtab, compilerMessages);
+		exprFalse.returnType(symtab, compilerMessages);
 
 		return returnType;
 	}

--- a/src/org/bds/lang/expression/ExpressionDelegateBinary.java
+++ b/src/org/bds/lang/expression/ExpressionDelegateBinary.java
@@ -47,8 +47,8 @@ public class ExpressionDelegateBinary extends ExpressionBinary {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
-		returnType = expr.returnType(symtab);
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
+		returnType = expr.returnType(symtab, compilerMessages);
 		return returnType;
 	}
 

--- a/src/org/bds/lang/expression/ExpressionDepOperator.java
+++ b/src/org/bds/lang/expression/ExpressionDepOperator.java
@@ -73,13 +73,13 @@ public class ExpressionDepOperator extends Expression {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		// Make sure we calculate return type fo all expressions
 		for (Expression e : left)
-			e.returnType(symtab);
+			e.returnType(symtab, compilerMessages);
 
 		for (Expression e : right)
-			e.returnType(symtab);
+			e.returnType(symtab, compilerMessages);
 
 		returnType = Types.BOOL;
 		return returnType;

--- a/src/org/bds/lang/expression/ExpressionGoal.java
+++ b/src/org/bds/lang/expression/ExpressionGoal.java
@@ -24,7 +24,7 @@ public class ExpressionGoal extends ExpressionUnary {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 		returnType = TypeList.get(Types.STRING);
 		return returnType;

--- a/src/org/bds/lang/expression/ExpressionList.java
+++ b/src/org/bds/lang/expression/ExpressionList.java
@@ -51,12 +51,12 @@ public class ExpressionList extends Expression {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		Type type = null;
 		for (Expression expr : expressions)
-			type = expr.returnType(symtab);
+			type = expr.returnType(symtab, compilerMessages);
 
 		returnType = type;
 		return returnType;

--- a/src/org/bds/lang/expression/ExpressionLogic.java
+++ b/src/org/bds/lang/expression/ExpressionLogic.java
@@ -21,10 +21,10 @@ public class ExpressionLogic extends ExpressionBinary {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		super.returnType(symtab);
+		super.returnType(symtab, compilerMessages);
 		returnType = Types.BOOL;
 
 		return returnType;

--- a/src/org/bds/lang/expression/ExpressionMath.java
+++ b/src/org/bds/lang/expression/ExpressionMath.java
@@ -1,6 +1,7 @@
 package org.bds.lang.expression;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.bds.compile.CompilerMessages;
 import org.bds.lang.BdsNode;
 import org.bds.lang.type.Type;
 import org.bds.lang.type.Types;
@@ -20,10 +21,10 @@ public class ExpressionMath extends ExpressionBinary {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		super.returnType(symtab);
+		super.returnType(symtab, compilerMessages);
 
 		if (right == null) {
 			if (left.canCastToInt()) returnType = Types.INT;

--- a/src/org/bds/lang/expression/ExpressionNew.java
+++ b/src/org/bds/lang/expression/ExpressionNew.java
@@ -42,7 +42,7 @@ public class ExpressionNew extends MethodCall {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		// Calculate return types for expr and args
@@ -56,7 +56,7 @@ public class ExpressionNew extends MethodCall {
 		args = Args.getArgsThis(args, expresionThis);
 
 		// Calculate return type for args
-		args.returnType(symtab);
+		args.returnType(symtab, compilerMessages);
 
 		// Find method
 		functionDeclaration = findMethod(symtab, thisType, args);

--- a/src/org/bds/lang/expression/ExpressionPlus.java
+++ b/src/org/bds/lang/expression/ExpressionPlus.java
@@ -31,10 +31,10 @@ public class ExpressionPlus extends ExpressionMath {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		super.returnType(symtab);
+		super.returnType(symtab, compilerMessages);
 
 		if (left.canCastToInt() && right.canCastToInt()) {
 			// Int + Int

--- a/src/org/bds/lang/expression/ExpressionSys.java
+++ b/src/org/bds/lang/expression/ExpressionSys.java
@@ -48,7 +48,7 @@ public class ExpressionSys extends Expression {
 	 * Sys expression always returns the task id, which is a string
 	 */
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		returnType = Types.STRING;
 		return returnType;
 	}

--- a/src/org/bds/lang/expression/ExpressionTask.java
+++ b/src/org/bds/lang/expression/ExpressionTask.java
@@ -112,10 +112,10 @@ public class ExpressionTask extends ExpressionWithScope {
 	 * Task expression always returns the task id, which is a string
 	 */
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		// Calculate options' return type
-		if (options != null) options.returnType(symtab);
-		if (statement != null) statement.returnType(symtab);
+		if (options != null) options.returnType(symtab, compilerMessages);
+		if (statement != null) statement.returnType(symtab, compilerMessages);
 
 		// Task expressions return a task ID (a string)
 		returnType = Types.STRING;
@@ -406,7 +406,7 @@ public class ExpressionTask extends ExpressionWithScope {
 
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
-		returnType(symtab);
+		returnType(symtab, compilerMessages);
 		if (options != null) options.typeCheck(symtab, compilerMessages);
 		if (statement != null) statement.typeCheck(symtab, compilerMessages);
 	}

--- a/src/org/bds/lang/expression/ExpressionTimes.java
+++ b/src/org/bds/lang/expression/ExpressionTimes.java
@@ -26,10 +26,10 @@ public class ExpressionTimes extends ExpressionMath {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		super.returnType(symtab);
+		super.returnType(symtab, compilerMessages);
 
 		if (isReturnTypesNotNull()) {
 			if (left.isString() || right.isString()) returnType = Types.STRING;

--- a/src/org/bds/lang/expression/ExpressionUnary.java
+++ b/src/org/bds/lang/expression/ExpressionUnary.java
@@ -46,10 +46,10 @@ public class ExpressionUnary extends Expression {
 	 * Which type does this expression return?
 	 */
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		returnType = expr.returnType(symtab);
+		returnType = expr.returnType(symtab, compilerMessages);
 		return returnType;
 	}
 

--- a/src/org/bds/lang/expression/ExpressionUnaryMinus.java
+++ b/src/org/bds/lang/expression/ExpressionUnaryMinus.java
@@ -25,10 +25,10 @@ public class ExpressionUnaryMinus extends ExpressionUnary {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		expr.returnType(symtab);
+		expr.returnType(symtab, compilerMessages);
 
 		if (expr.canCastToInt()) returnType = Types.INT;
 		else if (expr.canCastToReal()) returnType = Types.REAL;

--- a/src/org/bds/lang/expression/ExpressionUnaryPlusMinus.java
+++ b/src/org/bds/lang/expression/ExpressionUnaryPlusMinus.java
@@ -17,77 +17,77 @@ import org.bds.symbol.SymbolTable;
  */
 public class ExpressionUnaryPlusMinus extends ExpressionUnary {
 
-	private static final long serialVersionUID = -5030008162832737754L;
+    private static final long serialVersionUID = -5030008162832737754L;
 
-	public ExpressionUnaryPlusMinus(BdsNode parent, ParseTree tree) {
-		super(parent, tree);
-	}
+    public ExpressionUnaryPlusMinus(BdsNode parent, ParseTree tree) {
+        super(parent, tree);
+    }
 
-	@Override
-	protected void parse(ParseTree tree) {
-		op = tree.getChild(0).getText();
-		if (!op.equals("-") && !op.equals("+")) compileError("Unimplemented operator '" + op + "'. This should never happen!");
+    @Override
+    protected void parse(ParseTree tree) {
+        op = tree.getChild(0).getText();
+        if (!op.equals("-") && !op.equals("+")) compileError("Unimplemented operator '" + op + "'. This should never happen!");
 
-		expr = (Expression) factory(tree, 1);
-	}
+        expr = (Expression) factory(tree, 1);
+    }
 
-	@Override
-	public Type returnType(SymbolTable symtab) {
-		if (returnType != null) return returnType;
+    @Override
+    public Type returnType(SymbolTable symtab) {
+        if (returnType != null) return returnType;
 
-		expr.returnType(symtab);
+        expr.returnType(symtab);
 
-		if (expr.canCastToInt()) returnType = Types.INT;
-		else if (expr.canCastToReal()) returnType = Types.REAL;
-		else return null; // Cannot cast to 'int' or 'real'. This should never happen!"
+        if (expr.canCastToInt()) returnType = Types.INT;
+        else if (expr.canCastToReal()) returnType = Types.REAL;
+        else compileError("Unary expression '" + op + "' unknown return type.");
 
-		return returnType;
-	}
+        return returnType;
+    }
 
-	@Override
-	public String toAsm() {
-		switch (op) {
-		case "+":
-			return toAsmUnaryPlus();
-		case "-":
-			return toAsmUnaryMinus();
-		default:
-			compileError("Unimplemented operator '" + op + "'. This should never happen!");
-			return "";
-		}
-	}
+    @Override
+    public String toAsm() {
+        switch (op) {
+            case "+":
+                return toAsmUnaryPlus();
+            case "-":
+                return toAsmUnaryMinus();
+            default:
+                compileError("Unimplemented operator '" + op + "'.");
+                return "";
+        }
+    }
 
-	String toAsmUnaryMinus() {
-		// Int expression
-		if (isInt()) {
-			if (isLiteralInt()) {
-				// If it's a literal, just use the minus sign in the literal
-				return ((LiteralInt) expr).toAsm(true);
-			}
-			return "pushi 0\n" + expr.toAsm() + "subi\n";
-		}
+    String toAsmUnaryMinus() {
+        // Int expression
+        if (isInt()) {
+            if (isLiteralInt()) {
+                // If it's a literal, just use the minus sign in the literal
+                return ((LiteralInt) expr).toAsm(true);
+            }
+            return "pushi 0\n" + expr.toAsm() + "subi\n";
+        } else if (isReal()) {
+            // Real expression
+            if (isLiteralReal()) {
+                // If it's a literal, just use the minus sign in the literal
+                return ((LiteralReal) expr).toAsm(true);
+            }
+            return "pushr 0.0\n" + expr.toAsm() + "subr\n";
+        } else if (returnType == null) {
+            compileError("Unary expression '" + op + "' unknown return type.");
+        } else {
+            compileError("Cannot cast " + returnType + " to 'int' or 'real'.");
+        }
+        return "";
+    }
 
-		// Real expression
-		if (isReal()) {
-			if (isLiteralReal()) {
-				// If it's a literal, just use the minus sign in the literal
-				return ((LiteralReal) expr).toAsm(true);
-			}
-			return "pushr 0.0\n" + expr.toAsm() + "subr\n";
-		}
+    String toAsmUnaryPlus() {
+        return expr.toAsm();
+    }
 
-		compileError("Cannot cast to 'int' or 'real'. This should never happen!");
-		return "";
-	}
-
-	String toAsmUnaryPlus() {
-		return expr.toAsm();
-	}
-
-	@Override
-	public void typeCheckNotNull(SymbolTable symtab, CompilerMessages compilerMessages) {
-		// Can we transform to an int?
-		if (!expr.canCastToInt() && !expr.canCastToReal()) compilerMessages.add(this, "Cannot cast expression to int or real", MessageType.ERROR);
-	}
+    @Override
+    public void typeCheckNotNull(SymbolTable symtab, CompilerMessages compilerMessages) {
+        // Can we transform to an int?
+        if (!expr.canCastToInt() && !expr.canCastToReal()) compilerMessages.add(this, "Cannot cast expression to int or real", MessageType.ERROR);
+    }
 
 }

--- a/src/org/bds/lang/expression/ExpressionUnaryPlusMinus.java
+++ b/src/org/bds/lang/expression/ExpressionUnaryPlusMinus.java
@@ -39,7 +39,7 @@ public class ExpressionUnaryPlusMinus extends ExpressionUnary {
 
         if (expr.canCastToInt()) returnType = Types.INT;
         else if (expr.canCastToReal()) returnType = Types.REAL;
-        else compileError("Unary expression '" + op + "' unknown return type.");
+        else compilerMessages.add(this, "Unary expression '" + op + "' unknown return type.", MessageType.ERROR);
 
         return returnType;
     }

--- a/src/org/bds/lang/expression/ExpressionUnaryPlusMinus.java
+++ b/src/org/bds/lang/expression/ExpressionUnaryPlusMinus.java
@@ -32,10 +32,10 @@ public class ExpressionUnaryPlusMinus extends ExpressionUnary {
     }
 
     @Override
-    public Type returnType(SymbolTable symtab) {
+    public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
         if (returnType != null) return returnType;
 
-        expr.returnType(symtab);
+        expr.returnType(symtab, compilerMessages);
 
         if (expr.canCastToInt()) returnType = Types.INT;
         else if (expr.canCastToReal()) returnType = Types.REAL;

--- a/src/org/bds/lang/expression/ExpressionVariableInitImplicit.java
+++ b/src/org/bds/lang/expression/ExpressionVariableInitImplicit.java
@@ -34,10 +34,10 @@ public class ExpressionVariableInitImplicit extends Expression {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		returnType = vInit.getExpression().returnType(symtab);
+		returnType = vInit.getExpression().returnType(symtab, compilerMessages);
 		return returnType;
 	}
 
@@ -60,7 +60,7 @@ public class ExpressionVariableInitImplicit extends Expression {
 		if (symtab.hasTypeLocal(varName)) compilerMessages.add(this, "Duplicate local name " + varName, MessageType.ERROR);
 
 		// Calculate implicit data type
-		Type type = vInit.getExpression().returnType(symtab);
+		Type type = vInit.getExpression().returnType(symtab, compilerMessages);
 
 		// Add variable to scope
 		if ((varName != null) && (type != null)) symtab.addVariable(varName, type);

--- a/src/org/bds/lang/expression/ExpressionWrapper.java
+++ b/src/org/bds/lang/expression/ExpressionWrapper.java
@@ -36,10 +36,10 @@ public class ExpressionWrapper extends Expression {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		returnType = expression.returnType(symtab);
+		returnType = expression.returnType(symtab, compilerMessages);
 		return returnType;
 	}
 

--- a/src/org/bds/lang/expression/ReferenceField.java
+++ b/src/org/bds/lang/expression/ReferenceField.java
@@ -40,10 +40,10 @@ public class ReferenceField extends ReferenceVar {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		Type classType = exprObj.returnType(symtab);
+		Type classType = exprObj.returnType(symtab, compilerMessages);
 		if (classType == null) return null;
 		if (classType.isClass()) {
 			returnType = ((TypeClass) classType).resolve(name);
@@ -73,7 +73,7 @@ public class ReferenceField extends ReferenceVar {
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
 		// Calculate return type
-		returnType(symtab);
+		returnType(symtab, compilerMessages);
 
 		if ((exprObj.getReturnType() != null) && !exprObj.getReturnType().isClass()) {
 			compilerMessages.add(this, "Expression '" + exprObj + "' is not an object", MessageType.ERROR);

--- a/src/org/bds/lang/expression/ReferenceList.java
+++ b/src/org/bds/lang/expression/ReferenceList.java
@@ -91,11 +91,11 @@ public class ReferenceList extends Reference {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		exprIdx.returnType(symtab);
-		Type nameType = exprList.returnType(symtab);
+		exprIdx.returnType(symtab, compilerMessages);
+		Type nameType = exprList.returnType(symtab, compilerMessages);
 
 		if (nameType == null) return null;
 		if (nameType.isList()) returnType = ((TypeList) nameType).getElementType();
@@ -125,7 +125,7 @@ public class ReferenceList extends Reference {
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
 		// Calculate return type
-		returnType(symtab);
+		returnType(symtab, compilerMessages);
 
 		if ((exprList.getReturnType() != null) && !exprList.isList()) {
 			compilerMessages.add(this, "Expression '" + exprList + "' is not a list/array", MessageType.ERROR);

--- a/src/org/bds/lang/expression/ReferenceMap.java
+++ b/src/org/bds/lang/expression/ReferenceMap.java
@@ -93,12 +93,12 @@ public class ReferenceMap extends Reference {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
-		expressionKey.returnType(symtab);
+		expressionKey.returnType(symtab, compilerMessages);
 
 		// Retrieve map from scope
-		Type mapType = exprMap.returnType(symtab);
+		Type mapType = exprMap.returnType(symtab, compilerMessages);
 		if (mapType != null && mapType.isMap()) {
 			returnType = ((TypeMap) mapType).getValueType();
 		}
@@ -128,7 +128,7 @@ public class ReferenceMap extends Reference {
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
 		// Calculate return type
-		returnType(symtab);
+		returnType(symtab, compilerMessages);
 
 		// Is it a map?
 		if (!exprMap.isMap()) {

--- a/src/org/bds/lang/expression/ReferenceThis.java
+++ b/src/org/bds/lang/expression/ReferenceThis.java
@@ -34,7 +34,7 @@ public class ReferenceThis extends ReferenceVar {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 		returnType = symtab.resolve(ClassDeclaration.VAR_THIS);
 		return returnType;
@@ -43,7 +43,7 @@ public class ReferenceThis extends ReferenceVar {
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
 		// Calculate return type
-		returnType(symtab);
+		returnType(symtab, compilerMessages);
 	}
 
 }

--- a/src/org/bds/lang/expression/ReferenceVar.java
+++ b/src/org/bds/lang/expression/ReferenceVar.java
@@ -88,7 +88,7 @@ public class ReferenceVar extends Reference {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 		returnType = findType(symtab);
 		return returnType;
@@ -115,7 +115,7 @@ public class ReferenceVar extends Reference {
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
 		// Calculate return type
-		returnType(symtab);
+		returnType(symtab, compilerMessages);
 
 		if (returnType == null) {
 			compilerMessages.add(this, "Symbol '" + name + "' cannot be resolved", MessageType.ERROR);

--- a/src/org/bds/lang/statement/Args.java
+++ b/src/org/bds/lang/statement/Args.java
@@ -70,13 +70,13 @@ public class Args extends BdsNode {
 	 * Calculate return type for every expression
 	 */
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		if (arguments != null) {
 			for (Expression e : arguments)
 				if (e.getReturnType() == null) // Only assign this to show that calculation was already performed
-					returnType = e.returnType(symtab);
+					returnType = e.returnType(symtab, compilerMessages);
 
 		} else returnType = Types.VOID;
 

--- a/src/org/bds/lang/statement/Case.java
+++ b/src/org/bds/lang/statement/Case.java
@@ -131,7 +131,7 @@ public class Case extends StatementWithScope {
 	@Override
 	public void typeCheckNotNull(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (expression != null) {
-			Type caseExprType = expression.returnType(symtab);
+			Type caseExprType = expression.returnType(symtab, compilerMessages);
 
 			Expression switchExpr = ((Switch) parent).getSwitchExpr();
 			if (switchExpr == null) {

--- a/src/org/bds/lang/statement/Checkpoint.java
+++ b/src/org/bds/lang/statement/Checkpoint.java
@@ -53,7 +53,7 @@ public class Checkpoint extends Statement {
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (expr != null) {
-			expr.returnType(symtab);
+			expr.returnType(symtab, compilerMessages);
 			if (!expr.getReturnType().isString()) compilerMessages.add(this, "Checkpoint argument should be a string (file name)", MessageType.ERROR);
 		}
 	}

--- a/src/org/bds/lang/statement/ClassDeclaration.java
+++ b/src/org/bds/lang/statement/ClassDeclaration.java
@@ -207,7 +207,7 @@ public class ClassDeclaration extends Block {
     }
 
     @Override
-    public Type returnType(SymbolTable symtab) {
+    public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
         if (returnType != null) return returnType;
 
         if (classNameParent != null) {
@@ -216,14 +216,14 @@ public class ClassDeclaration extends Block {
         }
 
         for (VarDeclaration vd : fieldDecl)
-            vd.returnType(symtab);
+            vd.returnType(symtab, compilerMessages);
 
         for (FunctionDeclaration fd : methodDecl)
-            fd.returnType(symtab);
+            fd.returnType(symtab, compilerMessages);
 
         if (statements != null) {
             for (Statement s : statements)
-                s.returnType(symtab);
+                s.returnType(symtab, compilerMessages);
         }
 
         returnType = getType();

--- a/src/org/bds/lang/statement/Exit.java
+++ b/src/org/bds/lang/statement/Exit.java
@@ -31,11 +31,11 @@ public class Exit extends Statement {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		// Calculate expression's return type
-		if (expr != null) expr.returnType(symtab);
+		if (expr != null) expr.returnType(symtab, compilerMessages);
 
 		// Program's return type is 'int' (exit code)
 		returnType = Types.INT;
@@ -60,7 +60,7 @@ public class Exit extends Statement {
 
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
-		returnType(symtab);
+		returnType(symtab, compilerMessages);
 
 		if ((expr != null) //
 				&& (expr.getReturnType() != null) //

--- a/src/org/bds/lang/statement/ForLoopList.java
+++ b/src/org/bds/lang/statement/ForLoopList.java
@@ -56,8 +56,8 @@ public class ForLoopList extends StatementWithScope {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
-		returnType = expression.returnType(symtab);
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
+		returnType = expression.returnType(symtab, compilerMessages);
 		return returnType;
 	}
 

--- a/src/org/bds/lang/statement/FunctionCall.java
+++ b/src/org/bds/lang/statement/FunctionCall.java
@@ -113,10 +113,10 @@ public class FunctionCall extends Expression {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
-		args.returnType(symtab);
+		args.returnType(symtab, compilerMessages);
 
 		ValueFunction tfunc = symtab.findFunction(functionName, args);
 		if (tfunc != null) {

--- a/src/org/bds/lang/statement/If.java
+++ b/src/org/bds/lang/statement/If.java
@@ -85,7 +85,7 @@ public class If extends Statement {
 
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
-		Type retType = condition.returnType(symtab);
+		Type retType = condition.returnType(symtab, compilerMessages);
 		if ((condition != null) //
 				&& !condition.isBool() //
 				&& (retType != null) //

--- a/src/org/bds/lang/statement/MethodCall.java
+++ b/src/org/bds/lang/statement/MethodCall.java
@@ -56,13 +56,13 @@ public class MethodCall extends FunctionCall {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		// Calculate return types for expr and args
 		// Note that expresionThis is null in ExpressionNew (which is a MethodCall)
-		Type exprType = (expresionThis != null ? expresionThis.returnType(symtab) : null);
-		args.returnType(symtab);
+		Type exprType = (expresionThis != null ? expresionThis.returnType(symtab, compilerMessages) : null);
+		args.returnType(symtab, compilerMessages);
 
 		// Find method
 		functionDeclaration = findMethod(symtab, exprType, args);

--- a/src/org/bds/lang/statement/Print.java
+++ b/src/org/bds/lang/statement/Print.java
@@ -31,11 +31,11 @@ public class Print extends Statement {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		// Calculate expression's return type
-		if (expr != null) expr.returnType(symtab);
+		if (expr != null) expr.returnType(symtab, compilerMessages);
 
 		returnType = Types.STRING;
 		return returnType;
@@ -57,7 +57,7 @@ public class Print extends Statement {
 
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
-		returnType(symtab);
+		returnType(symtab, compilerMessages);
 
 		if (expr != null && !expr.canCastToString()) {
 			compilerMessages.add(this, "Cannot cast " + expr.getReturnType() + " to " + returnType, MessageType.ERROR);

--- a/src/org/bds/lang/statement/Return.java
+++ b/src/org/bds/lang/statement/Return.java
@@ -48,11 +48,11 @@ public class Return extends Statement {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		// Calculate expression's return type
-		if (expr != null) expr.returnType(symtab);
+		if (expr != null) expr.returnType(symtab, compilerMessages);
 
 		// Find enclosing function / method
 		functionDecl = findParentFunction();
@@ -83,7 +83,7 @@ public class Return extends Statement {
 
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
-		returnType(symtab);
+		returnType(symtab, compilerMessages);
 
 		if (expr == null) {
 			// Expression is null => return is 'void'

--- a/src/org/bds/lang/statement/StatementWithScope.java
+++ b/src/org/bds/lang/statement/StatementWithScope.java
@@ -49,7 +49,7 @@ public class StatementWithScope extends Statement {
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
 		// Calculate return type
-		returnType = returnType(symtab);
+		returnType = returnType(symtab, compilerMessages);
 
 		// Are return types non-null?
 		// Note: null returnTypes happen if variables are missing.

--- a/src/org/bds/lang/statement/Switch.java
+++ b/src/org/bds/lang/statement/Switch.java
@@ -150,7 +150,7 @@ public class Switch extends Statement {
 
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
-		if (switchExpr != null) switchExpr.returnType(symtab);
+		if (switchExpr != null) switchExpr.returnType(symtab, compilerMessages);
 	}
 
 }

--- a/src/org/bds/lang/statement/Throw.java
+++ b/src/org/bds/lang/statement/Throw.java
@@ -48,9 +48,9 @@ public class Throw extends StatementWithScope {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
-		returnType = expr.returnType(symtab);
+		returnType = expr.returnType(symtab, compilerMessages);
 		return returnType;
 	}
 

--- a/src/org/bds/lang/statement/VarDeclaration.java
+++ b/src/org/bds/lang/statement/VarDeclaration.java
@@ -135,7 +135,7 @@ public class VarDeclaration extends Statement {
 				compilerMessages.add(this, "Duplicate local name '" + varName + "'" + other, MessageType.ERROR);
 			} else {
 				// Calculate implicit data type
-				if (implicit && type == null) type = vi.getExpression().returnType(symtab);
+				if (implicit && type == null) type = vi.getExpression().returnType(symtab, compilerMessages);
 
 				// Sanity check: Don't declare void variables
 				if (type != null && type.isVoid()) {

--- a/src/org/bds/lang/statement/VariableInit.java
+++ b/src/org/bds/lang/statement/VariableInit.java
@@ -173,7 +173,7 @@ public class VariableInit extends BdsNode {
 
         // Calculate expression type
         if (expression != null) {
-            Type exprRetType = expression.returnType(symtab);
+            Type exprRetType = expression.returnType(symtab, compilerMessages);
 
             // Compare types
             if ((varType == null) || (exprRetType == null)) {

--- a/src/org/bds/lang/statement/VariableInitImplicit.java
+++ b/src/org/bds/lang/statement/VariableInitImplicit.java
@@ -62,7 +62,7 @@ public class VariableInitImplicit extends VariableInit {
 
 		// Calculate expression type
 		if (expression != null) {
-			Type exprRetType = expression.returnType(symtab);
+			Type exprRetType = expression.returnType(symtab, compilerMessages);
 
 			// Compare types
 			if ((varType == null) || (exprRetType == null)) {

--- a/src/org/bds/lang/statement/While.java
+++ b/src/org/bds/lang/statement/While.java
@@ -69,7 +69,7 @@ public class While extends Statement {
 
 	@Override
 	public void typeCheck(SymbolTable symtab, CompilerMessages compilerMessages) {
-		if (condition != null) condition.returnType(symtab);
+		if (condition != null) condition.returnType(symtab, compilerMessages);
 		if ((condition != null) && !condition.isBool()) compilerMessages.add(this, "While loop condition must be a bool expression", MessageType.ERROR);
 	}
 

--- a/src/org/bds/lang/value/InterpolateVars.java
+++ b/src/org/bds/lang/value/InterpolateVars.java
@@ -234,7 +234,7 @@ public class InterpolateVars extends Literal {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		returnType = Types.STRING;

--- a/src/org/bds/lang/value/Literal.java
+++ b/src/org/bds/lang/value/Literal.java
@@ -37,7 +37,7 @@ public abstract class Literal extends Expression {
 	protected abstract Value parseValue(ParseTree tree);
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 		returnType = value.getType();
 		return returnType;

--- a/src/org/bds/lang/value/LiteralList.java
+++ b/src/org/bds/lang/value/LiteralList.java
@@ -50,14 +50,14 @@ public class LiteralList extends Literal {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		// Calculate elementType
 		Type baseType = null;
 		for (BdsNode node : values) {
 			Expression expr = (Expression) node;
-			Type typeExpr = expr.returnType(symtab);
+			Type typeExpr = expr.returnType(symtab, compilerMessages);
 
 			if (typeExpr != null) {
 				if (baseType == null) {
@@ -133,7 +133,7 @@ public class LiteralList extends Literal {
 
 		for (BdsNode node : values) {
 			Expression expr = (Expression) node;
-			Type typeExpr = expr.returnType(symtab);
+			Type typeExpr = expr.returnType(symtab, compilerMessages);
 
 			// Can we cast ?
 			if ((typeExpr != null) && !typeExpr.canCastTo(baseType)) {

--- a/src/org/bds/lang/value/LiteralListEmpty.java
+++ b/src/org/bds/lang/value/LiteralListEmpty.java
@@ -1,6 +1,7 @@
 package org.bds.lang.value;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.bds.compile.CompilerMessages;
 import org.bds.lang.BdsNode;
 import org.bds.lang.expression.Expression;
 import org.bds.lang.expression.ExpressionAssignment;
@@ -29,7 +30,7 @@ public class LiteralListEmpty extends LiteralList {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 		returnType = TypeList.get(Types.ANY);
 		return returnType;

--- a/src/org/bds/lang/value/LiteralListString.java
+++ b/src/org/bds/lang/value/LiteralListString.java
@@ -1,6 +1,7 @@
 package org.bds.lang.value;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.bds.compile.CompilerMessages;
 import org.bds.lang.BdsNode;
 import org.bds.lang.expression.Expression;
 import org.bds.lang.type.Type;
@@ -23,7 +24,7 @@ public class LiteralListString extends LiteralList {
     }
 
     @Override
-    public Type returnType(SymbolTable symtab) {
+    public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
         if (returnType != null) return returnType;
         runtimeError("This should never happen!");
         return null;

--- a/src/org/bds/lang/value/LiteralMap.java
+++ b/src/org/bds/lang/value/LiteralMap.java
@@ -51,7 +51,7 @@ public class LiteralMap extends Literal {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 
 		// Calculate elementType
@@ -59,7 +59,7 @@ public class LiteralMap extends Literal {
 		Type keyType = null;
 		for (BdsNode node : values) {
 			Expression expr = (Expression) node;
-			Type typeExpr = expr.returnType(symtab);
+			Type typeExpr = expr.returnType(symtab, compilerMessages);
 
 			if (typeExpr != null) {
 				if (valueType == null) {
@@ -135,7 +135,7 @@ public class LiteralMap extends Literal {
 		Type valueType = ((TypeMap) returnType).getValueType();
 		for (BdsNode node : values) {
 			Expression expr = (Expression) node;
-			Type typeExpr = expr.returnType(symtab);
+			Type typeExpr = expr.returnType(symtab, compilerMessages);
 
 			// Can we cast ?
 			if ((typeExpr != null) && !typeExpr.canCastTo(valueType)) {
@@ -147,7 +147,7 @@ public class LiteralMap extends Literal {
 		Type keyType = ((TypeMap) returnType).getKeyType();
 		for (BdsNode node : keys) {
 			Expression expr = (Expression) node;
-			Type typeExpr = expr.returnType(symtab);
+			Type typeExpr = expr.returnType(symtab, compilerMessages);
 
 			// Can we cast ?
 			if ((typeExpr != null) && !typeExpr.canCastTo(keyType)) {

--- a/src/org/bds/lang/value/LiteralMap.java
+++ b/src/org/bds/lang/value/LiteralMap.java
@@ -54,9 +54,7 @@ public class LiteralMap extends Literal {
 	public Type returnType(SymbolTable symtab) {
 		if (returnType != null) return returnType;
 
-		//---
 		// Calculate elementType
-		//---
 		Type valueType = null;
 		Type keyType = null;
 		for (BdsNode node : values) {

--- a/src/org/bds/lang/value/LiteralMapEmpty.java
+++ b/src/org/bds/lang/value/LiteralMapEmpty.java
@@ -1,6 +1,7 @@
 package org.bds.lang.value;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.bds.compile.CompilerMessages;
 import org.bds.lang.BdsNode;
 import org.bds.lang.expression.Expression;
 import org.bds.lang.expression.ExpressionAssignment;
@@ -30,7 +31,7 @@ public class LiteralMapEmpty extends LiteralMap {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		if (returnType != null) return returnType;
 		returnType = TypeMap.get(Types.ANY, Types.ANY);
 		return returnType;

--- a/src/org/bds/lang/value/LiteralNull.java
+++ b/src/org/bds/lang/value/LiteralNull.java
@@ -1,6 +1,7 @@
 package org.bds.lang.value;
 
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.bds.compile.CompilerMessages;
 import org.bds.lang.BdsNode;
 import org.bds.lang.type.Type;
 import org.bds.lang.type.Types;
@@ -35,7 +36,7 @@ public class LiteralNull extends Literal {
 	}
 
 	@Override
-	public Type returnType(SymbolTable symtab) {
+	public Type returnType(SymbolTable symtab, CompilerMessages compilerMessages) {
 		return Types.NULL;
 	}
 

--- a/src/org/bds/test/unit/TestCasesLang.java
+++ b/src/org/bds/test/unit/TestCasesLang.java
@@ -443,7 +443,8 @@ public class TestCasesLang extends TestCasesBase {
 		//		at org.bds.run.BdsRun.run(BdsRun.java:440)
 		//		at org.bds.Bds.run(Bds.java:405)
 		//		at org.bds.Bds.main(Bds.java:56)
-        compileOk("test/test73.bds");
+        verbose = true;
+        compileErrors("test/test73.bds", "Unary expression '-' unknown return type");
     }
 
     @Test

--- a/src/org/bds/test/unit/TestCasesLang.java
+++ b/src/org/bds/test/unit/TestCasesLang.java
@@ -1,425 +1,468 @@
 package org.bds.test.unit;
 
 import org.bds.test.TestCasesBase;
-import org.bds.util.Gpr;
 import org.junit.Test;
 
 /**
  * Test cases for language & compilation
- *
+ * <p>
  * Note: These test cases just check language parsing and compilation (what is supposed to compile OK, and what is not).
  *
  * @author pcingola
- *
  */
 public class TestCasesLang extends TestCasesBase {
 
-	@Test
-	public void test00() {
-		compileOk("test/test00.bds");
-	}
-
-	@Test
-	public void test01() {
-		compileOk("test/test01.bds");
-	}
-
-	@Test
-	public void test02() {
-		compileOk("test/test02.bds");
-	}
-
-	@Test
-	public void test03() {
-		compileOk("test/test03.bds");
-	}
-
-	@Test
-	public void test04() {
-		compileOk("test/test04.bds");
-	}
-
-	@Test
-	public void test05() {
-		compileOk("test/test05.bds");
-	}
-
-	@Test
-	public void test06() {
-		compileOk("test/test06.bds");
-	}
-
-	@Test
-	public void test07() {
-		compileOk("test/test07.bds");
-	}
-
-	@Test
-	public void test08() {
-		String errs = "ERROR [ file 'test/test08.bds', line 11 ] :	Only variable reference can be used with ++ or -- operators\n";
-		compileErrors("test/test08.bds", errs);
-	}
-
-	@Test
-	public void test09() {
-		compileOk("test/test09.bds");
-	}
-
-	@Test
-	public void test10() {
-		String err = "ERROR [ file 'test/test10.bds', line 2 ] :	Symbol 'j' cannot be resolved\n";
-		compileErrors("test/test10.bds", err);
-	}
-
-	@Test
-	public void test11() {
-		String err = "ERROR [ file 'test/test11.bds', line 2 ] :	Symbol 'j' cannot be resolved\n";
-		compileErrors("test/test11.bds", err);
-	}
-
-	@Test
-	public void test12() {
-		compileOk("test/test12.bds");
-	}
-
-	@Test
-	public void test13() {
-		compileOk("test/test13.bds");
-	}
-
-	@Test
-	public void test14() {
-		String errs = "ERROR [ file 'test/test14.bds', line 3 ] :	Symbol 'i' cannot be resolved\n"//
-				+ "ERROR [ file 'test/test14.bds', line 4 ] :	Symbol 'i' cannot be resolved\n";
-
-		compileErrors("test/test14.bds", errs);
-	}
-
-	@Test
-	public void test15() {
-		String errs = "ERROR [ file 'test/test15.bds', line 4 ] :	Symbol 'j' cannot be resolved\n";
-		compileErrors("test/test15.bds", errs);
-	}
-
-	@Test
-	public void test16() {
-		compileOk("test/test16.bds");
-	}
-
-	@Test
-	public void test17() {
-		compileOk("test/test17.bds");
-	}
-
-	@Test
-	public void test18() {
-		compileOk("test/test18.bds");
-	}
-
-	@Test
-	public void test19() {
-		String errs = "ERROR [ file 'test/test19.bds', line 4 ] :	Duplicate local name 'i'\n";
-		compileErrors("test/test19.bds", errs);
-	}
-
-	@Test
-	public void test20() {
-		compileOk("test/test20.bds");
-	}
-
-	@Test
-	public void test21() {
-		compileOk("test/test21.bds");
-	}
-
-	@Test
-	public void test22() {
-		compileOk("test/test22.bds");
-	}
-
-	@Test
-	public void test23() {
-		compileOk("test/test23.bds");
-	}
-
-	@Test
-	public void test24() {
-		compileOk("test/test24.bds");
-	}
-
-	@Test
-	public void test25() {
-		compileOk("test/test25.bds");
-	}
-
-	@Test
-	public void test26() {
-		compileOk("test/test26.bds");
-	}
-
-	@Test
-	public void test27() {
-		String errs = "ERROR [ file 'test/test27.bds', line 2 ] :	Cannot cast real to int\n";
-		compileErrors("test/test27.bds", errs);
-	}
-
-	@Test
-	public void test28() {
-		compileOk("test/test28.bds");
-	}
-
-	@Test
-	public void test29() {
-		String errs = "ERROR [ file 'test/test29.bds', line 3 ] :	For loop condition must be a bool expression\n";
-		compileErrors("test/test29.bds", errs);
-	}
-
-	@Test
-	public void test30() {
-		String errs = "ERROR [ file 'test/test30.bds', line 4 ] :	Cannot cast real to int\n";
-		compileErrors("test/test30.bds", errs);
-	}
-
-	@Test
-	public void test31() {
-		String errs = "ERROR [ file 'test/test31.bds', line 4 ] :	Function has no return statement\n";
-		compileErrors("test/test31.bds", errs);
-	}
-
-	@Test
-	public void test32() {
-		compileOk("test/test32.bds");
-	}
-
-	@Test
-	public void test33() {
-		// As of bds version 3.0, this is no longer a compile error, it is just an "improper task"
-		//
-		//		String errs = "ERROR [ file 'test/test33.bds', line 7 ] :	Only sys statements are allowed in a task (line 11)\n";
-		//		compileErrors("test/test33.bds", errs);
-		//
-		compileOk("test/test33.bds");
-	}
-
-	@Test
-	public void test34() {
-		String errs = "ERROR [ file 'test/test34.bds', line 5 ] :	Function f(int) cannot be resolved\n";
-		compileErrors("test/test34.bds", errs);
-	}
-
-	@Test
-	public void test35() {
-		compileOk("test/test35.bds");
-	}
-
-	@Test
-	public void test36() {
-		String errs = "ERROR [ file 'test/test36.bds', line 3 ] :	Symbol 'j' cannot be resolved\n";
-		compileErrors("test/test36.bds", errs);
-	}
-
-	@Test
-	public void test37() {
-		String errs = "ERROR [ file 'test/test37.bds', line 16 ] :	Symbol 'fruit' cannot be resolved\n";
-		compileErrors("test/test37.bds", errs);
-	}
-
-	@Test
-	public void test38() {
-		String errs = "ERROR [ file 'test/test38.bds', line 6 ] :	Cannot cast string to int\n";
-		compileErrors("test/test38.bds", errs);
-	}
-
-	@Test
-	public void test39() {
-		String errs = "ERROR [ file 'test/test39.bds', line 6 ] :	Cannot cast string to int\n";
-		compileErrors("test/test39.bds", errs);
-	}
-
-	@Test
-	public void test40() {
-		String errs = "ERROR [ file 'test/test40.bds', line 6 ] :	Method int[].push(string) cannot be resolved\n";
-		compileErrors("test/test40.bds", errs);
-	}
-
-	@Test
-	public void test41() {
-		compileOk("test/test41.bds");
-	}
-
-	@Test
-	public void test42() {
-		compileOk("test/test42.bds");
-	}
-
-	@Test
-	public void test43() {
-		String errs = "ERROR [ file 'test/test43.bds', line 8 ] :	Cannot declare variable 'res' type 'void'";
-		compileErrors("test/test43.bds", errs);
-	}
-
-	@Test
-	public void test44() {
-		String errs = "ERROR [ file 'test/test44.bds', line 2 ] :	Cannot append int[] to string[]";
-		compileErrors("test/test44.bds", errs);
-	}
-
-	@Test
-	public void test45() {
-		compileOk("test/test45.bds");
-	}
-
-	@Test
-	public void test46() {
-		compileOk("test/test46.bds");
-	}
-
-	@Test
-	public void test47() {
-		String errs = "ERROR [ file 'test/test47.bds', line 5 ] :	Duplicate local name 'gsea'";
-		compileErrors("test/test47.bds", errs);
-	}
-
-	@Test
-	public void test48() {
-		// String errs = "ERROR [ file 'test/test48.bds', line 5 ] :	extraneous input ':=' expecting {<EOF>, 'while', '{', 'void', 'for', 'error', 'debug', 'int', 'include', 'task', '(', 'kill', '\n', 'println', 'exit', '++', '~', 'wait', 'dep', '+', 'goal', 'continue', 'return', ';', 'if', 'warning', 'break', 'print', 'switch', 'parallel', 'par', '[', '--', 'bool', '!', 'string', 'checkpoint', 'breakpoint', '-', 'real', BOOL_LITERAL, INT_LITERAL, REAL_LITERAL, STRING_LITERAL, STRING_LITERAL_SINGLE, HELP_LITERAL, SYS_LITERAL, TASK_LITERAL, ID}";
-		String errs = "ERROR [ file 'test/test48.bds', line 5 ] :	extraneous input ':=' expecting ";
-		compileErrors("test/test48.bds", errs);
-	}
-
-	@Test
-	public void test49() {
-		String errs = "ERROR [ file 'test/test49.bds', line 4 ] :\tTask has empty statement";
-		compileErrors("test/test49.bds", errs);
-	}
-
-	@Test
-	public void test50() {
-		String errs = "ERROR [ file 'test/test50.bds', line 6 ] :\tCannot assign to non-variable 'f(  )[0]'";
-		compileErrors("test/test50.bds", errs);
-	}
-
-	@Test
-	public void test51() {
-		String errs = "ERROR [ file 'test/test51.bds', line 6 ] :	Cannot assign to non-variable 'f(  ){\"hi\"}'";
-		compileErrors("test/test51.bds", errs);
-	}
-
-	@Test
-	public void test52() {
-		compileOk("test/test52.bds");
-	}
-
-	@Test
-	public void test53() {
-		compileOk("test/test53.bds");
-	}
-
-	@Test
-	public void test54() {
-		String errs = "ERROR [ file 'test/test54.bds', line 9 ] :	Switch expression and case expression types do not match (string vs int): case 7";
-		compileErrors("test/test54.bds", errs);
-	}
-
-	@Test
-	public void test55() {
-		String errs = "ERROR [ file 'test/test55.bds', line 15 ] :	Symbol 'b' cannot be resolved";
-		compileErrors("test/test55.bds", errs);
-	}
-
-	@Test
-	public void test56() {
-		compileErrors("test/test56.bds", "Cannot find class 'A'");
-	}
-
-	@Test
-	public void test57() {
-		compileErrors("test/test57.bds", "Cannot cast A to B");
-	}
-
-	@Test
-	public void test58() {
-		compileErrors("test/test58.bds", "Symbol 'out' cannot be resolved");
-	}
-
-	@Test
-	public void test59() {
-		compileErrors("test/test59.bds", "Expression should be string or string[], got '(A) -> string'");
-	}
-
-	@Test
-	public void test60() {
-		compileOk("test/test60.bds");
-	}
-
-	@Test
-	public void test61() {
-		compileOk("test/test61.bds");
-	}
-
-	@Test
-	public void test62() {
-		compileOk("test/test62.bds");
-	}
-
-	@Test
-	public void test63() {
-		compileErrors("test/test63.bds", "ERROR [ file 'test/test63.bds', line 5 ] :	Duplicate local name 'zzz'");
-	}
-
-	@Test
-	public void test64() {
-		compileErrors("test/test64.bds", "Duplicate function 'zzz() -> void'");
-	}
-
-	@Test
-	public void test65() {
-		compileErrors("test/test65.bds", "Duplicate method 'A.zzz(A) -> void'");
-	}
-
-	@Test
-	public void test66() {
-		compileOk("test/test66.bds");
-		compileOk("test/test66b.bds");
-	}
-
-	@Test
-	public void test67() {
-		compileOk("test/test67.bds");
-	}
-
-	@Test
-	public void test67b() {
-		compileErrors("test/test67b.bds", "Cannot cast A to C");
-	}
-
-	@Test
-	public void test68() {
-		// Switch with empty statement crashes compile
-		compileErrors("test/test68.bds", "Empty switch statment");
-	}
-
-	@Test
-	public void test69() {
-		// Assign result from 'void' function
-		compileErrors("test/test69.bds", "Cannot cast void to string[]");
-	}
-
-	@Test
-	public void test70() {
-		// Return different type of array
-		compileErrors("test/test70.bds", "Cannot cast A[] to B[]");
-	}
-
-	@Test
-	public void test71_castEmptyListOfObjects() {
-		// Initialize with an empty list of objects
-		compileOk("test/test71.bds");
-	}
-
-	@Test
-	public void test72_castEmptyMapOfObjects() {
-		// Initialize with an empty map of objects
-		compileOk("test/test72.bds");
-	}
+    @Test
+    public void test00() {
+        compileOk("test/test00.bds");
+    }
+
+    @Test
+    public void test01() {
+        compileOk("test/test01.bds");
+    }
+
+    @Test
+    public void test02() {
+        compileOk("test/test02.bds");
+    }
+
+    @Test
+    public void test03() {
+        compileOk("test/test03.bds");
+    }
+
+    @Test
+    public void test04() {
+        compileOk("test/test04.bds");
+    }
+
+    @Test
+    public void test05() {
+        compileOk("test/test05.bds");
+    }
+
+    @Test
+    public void test06() {
+        compileOk("test/test06.bds");
+    }
+
+    @Test
+    public void test07() {
+        compileOk("test/test07.bds");
+    }
+
+    @Test
+    public void test08() {
+        String errs = "ERROR [ file 'test/test08.bds', line 11 ] :	Only variable reference can be used with ++ or -- operators\n";
+        compileErrors("test/test08.bds", errs);
+    }
+
+    @Test
+    public void test09() {
+        compileOk("test/test09.bds");
+    }
+
+    @Test
+    public void test10() {
+        String err = "ERROR [ file 'test/test10.bds', line 2 ] :	Symbol 'j' cannot be resolved\n";
+        compileErrors("test/test10.bds", err);
+    }
+
+    @Test
+    public void test11() {
+        String err = "ERROR [ file 'test/test11.bds', line 2 ] :	Symbol 'j' cannot be resolved\n";
+        compileErrors("test/test11.bds", err);
+    }
+
+    @Test
+    public void test12() {
+        compileOk("test/test12.bds");
+    }
+
+    @Test
+    public void test13() {
+        compileOk("test/test13.bds");
+    }
+
+    @Test
+    public void test14() {
+        String errs = "ERROR [ file 'test/test14.bds', line 3 ] :	Symbol 'i' cannot be resolved\n"//
+                + "ERROR [ file 'test/test14.bds', line 4 ] :	Symbol 'i' cannot be resolved\n";
+
+        compileErrors("test/test14.bds", errs);
+    }
+
+    @Test
+    public void test15() {
+        String errs = "ERROR [ file 'test/test15.bds', line 4 ] :	Symbol 'j' cannot be resolved\n";
+        compileErrors("test/test15.bds", errs);
+    }
+
+    @Test
+    public void test16() {
+        compileOk("test/test16.bds");
+    }
+
+    @Test
+    public void test17() {
+        compileOk("test/test17.bds");
+    }
+
+    @Test
+    public void test18() {
+        compileOk("test/test18.bds");
+    }
+
+    @Test
+    public void test19() {
+        String errs = "ERROR [ file 'test/test19.bds', line 4 ] :	Duplicate local name 'i'\n";
+        compileErrors("test/test19.bds", errs);
+    }
+
+    @Test
+    public void test20() {
+        compileOk("test/test20.bds");
+    }
+
+    @Test
+    public void test21() {
+        compileOk("test/test21.bds");
+    }
+
+    @Test
+    public void test22() {
+        compileOk("test/test22.bds");
+    }
+
+    @Test
+    public void test23() {
+        compileOk("test/test23.bds");
+    }
+
+    @Test
+    public void test24() {
+        compileOk("test/test24.bds");
+    }
+
+    @Test
+    public void test25() {
+        compileOk("test/test25.bds");
+    }
+
+    @Test
+    public void test26() {
+        compileOk("test/test26.bds");
+    }
+
+    @Test
+    public void test27() {
+        String errs = "ERROR [ file 'test/test27.bds', line 2 ] :	Cannot cast real to int\n";
+        compileErrors("test/test27.bds", errs);
+    }
+
+    @Test
+    public void test28() {
+        compileOk("test/test28.bds");
+    }
+
+    @Test
+    public void test29() {
+        String errs = "ERROR [ file 'test/test29.bds', line 3 ] :	For loop condition must be a bool expression\n";
+        compileErrors("test/test29.bds", errs);
+    }
+
+    @Test
+    public void test30() {
+        String errs = "ERROR [ file 'test/test30.bds', line 4 ] :	Cannot cast real to int\n";
+        compileErrors("test/test30.bds", errs);
+    }
+
+    @Test
+    public void test31() {
+        String errs = "ERROR [ file 'test/test31.bds', line 4 ] :	Function has no return statement\n";
+        compileErrors("test/test31.bds", errs);
+    }
+
+    @Test
+    public void test32() {
+        compileOk("test/test32.bds");
+    }
+
+    @Test
+    public void test33() {
+        // As of bds version 3.0, this is no longer a compile error, it is just an "improper task"
+        //
+        //		String errs = "ERROR [ file 'test/test33.bds', line 7 ] :	Only sys statements are allowed in a task (line 11)\n";
+        //		compileErrors("test/test33.bds", errs);
+        //
+        compileOk("test/test33.bds");
+    }
+
+    @Test
+    public void test34() {
+        String errs = "ERROR [ file 'test/test34.bds', line 5 ] :	Function f(int) cannot be resolved\n";
+        compileErrors("test/test34.bds", errs);
+    }
+
+    @Test
+    public void test35() {
+        compileOk("test/test35.bds");
+    }
+
+    @Test
+    public void test36() {
+        String errs = "ERROR [ file 'test/test36.bds', line 3 ] :	Symbol 'j' cannot be resolved\n";
+        compileErrors("test/test36.bds", errs);
+    }
+
+    @Test
+    public void test37() {
+        String errs = "ERROR [ file 'test/test37.bds', line 16 ] :	Symbol 'fruit' cannot be resolved\n";
+        compileErrors("test/test37.bds", errs);
+    }
+
+    @Test
+    public void test38() {
+        String errs = "ERROR [ file 'test/test38.bds', line 6 ] :	Cannot cast string to int\n";
+        compileErrors("test/test38.bds", errs);
+    }
+
+    @Test
+    public void test39() {
+        String errs = "ERROR [ file 'test/test39.bds', line 6 ] :	Cannot cast string to int\n";
+        compileErrors("test/test39.bds", errs);
+    }
+
+    @Test
+    public void test40() {
+        String errs = "ERROR [ file 'test/test40.bds', line 6 ] :	Method int[].push(string) cannot be resolved\n";
+        compileErrors("test/test40.bds", errs);
+    }
+
+    @Test
+    public void test41() {
+        compileOk("test/test41.bds");
+    }
+
+    @Test
+    public void test42() {
+        compileOk("test/test42.bds");
+    }
+
+    @Test
+    public void test43() {
+        String errs = "ERROR [ file 'test/test43.bds', line 8 ] :	Cannot declare variable 'res' type 'void'";
+        compileErrors("test/test43.bds", errs);
+    }
+
+    @Test
+    public void test44() {
+        String errs = "ERROR [ file 'test/test44.bds', line 2 ] :	Cannot append int[] to string[]";
+        compileErrors("test/test44.bds", errs);
+    }
+
+    @Test
+    public void test45() {
+        compileOk("test/test45.bds");
+    }
+
+    @Test
+    public void test46() {
+        compileOk("test/test46.bds");
+    }
+
+    @Test
+    public void test47() {
+        String errs = "ERROR [ file 'test/test47.bds', line 5 ] :	Duplicate local name 'gsea'";
+        compileErrors("test/test47.bds", errs);
+    }
+
+    @Test
+    public void test48() {
+        // String errs = "ERROR [ file 'test/test48.bds', line 5 ] :	extraneous input ':=' expecting {<EOF>, 'while', '{', 'void', 'for', 'error', 'debug', 'int', 'include', 'task', '(', 'kill', '\n', 'println', 'exit', '++', '~', 'wait', 'dep', '+', 'goal', 'continue', 'return', ';', 'if', 'warning', 'break', 'print', 'switch', 'parallel', 'par', '[', '--', 'bool', '!', 'string', 'checkpoint', 'breakpoint', '-', 'real', BOOL_LITERAL, INT_LITERAL, REAL_LITERAL, STRING_LITERAL, STRING_LITERAL_SINGLE, HELP_LITERAL, SYS_LITERAL, TASK_LITERAL, ID}";
+        String errs = "ERROR [ file 'test/test48.bds', line 5 ] :	extraneous input ':=' expecting ";
+        compileErrors("test/test48.bds", errs);
+    }
+
+    @Test
+    public void test49() {
+        String errs = "ERROR [ file 'test/test49.bds', line 4 ] :\tTask has empty statement";
+        compileErrors("test/test49.bds", errs);
+    }
+
+    @Test
+    public void test50() {
+        String errs = "ERROR [ file 'test/test50.bds', line 6 ] :\tCannot assign to non-variable 'f(  )[0]'";
+        compileErrors("test/test50.bds", errs);
+    }
+
+    @Test
+    public void test51() {
+        String errs = "ERROR [ file 'test/test51.bds', line 6 ] :	Cannot assign to non-variable 'f(  ){\"hi\"}'";
+        compileErrors("test/test51.bds", errs);
+    }
+
+    @Test
+    public void test52() {
+        compileOk("test/test52.bds");
+    }
+
+    @Test
+    public void test53() {
+        compileOk("test/test53.bds");
+    }
+
+    @Test
+    public void test54() {
+        String errs = "ERROR [ file 'test/test54.bds', line 9 ] :	Switch expression and case expression types do not match (string vs int): case 7";
+        compileErrors("test/test54.bds", errs);
+    }
+
+    @Test
+    public void test55() {
+        String errs = "ERROR [ file 'test/test55.bds', line 15 ] :	Symbol 'b' cannot be resolved";
+        compileErrors("test/test55.bds", errs);
+    }
+
+    @Test
+    public void test56() {
+        compileErrors("test/test56.bds", "Cannot find class 'A'");
+    }
+
+    @Test
+    public void test57() {
+        compileErrors("test/test57.bds", "Cannot cast A to B");
+    }
+
+    @Test
+    public void test58() {
+        compileErrors("test/test58.bds", "Symbol 'out' cannot be resolved");
+    }
+
+    @Test
+    public void test59() {
+        compileErrors("test/test59.bds", "Expression should be string or string[], got '(A) -> string'");
+    }
+
+    @Test
+    public void test60() {
+        compileOk("test/test60.bds");
+    }
+
+    @Test
+    public void test61() {
+        compileOk("test/test61.bds");
+    }
+
+    @Test
+    public void test62() {
+        compileOk("test/test62.bds");
+    }
+
+    @Test
+    public void test63() {
+        compileErrors("test/test63.bds", "ERROR [ file 'test/test63.bds', line 5 ] :	Duplicate local name 'zzz'");
+    }
+
+    @Test
+    public void test64() {
+        compileErrors("test/test64.bds", "Duplicate function 'zzz() -> void'");
+    }
+
+    @Test
+    public void test65() {
+        compileErrors("test/test65.bds", "Duplicate method 'A.zzz(A) -> void'");
+    }
+
+    @Test
+    public void test66() {
+        compileOk("test/test66.bds");
+        compileOk("test/test66b.bds");
+    }
+
+    @Test
+    public void test67() {
+        compileOk("test/test67.bds");
+    }
+
+    @Test
+    public void test67b() {
+        compileErrors("test/test67b.bds", "Cannot cast A to C");
+    }
+
+    @Test
+    public void test68() {
+        // Switch with empty statement crashes compile
+        compileErrors("test/test68.bds", "Empty switch statment");
+    }
+
+    @Test
+    public void test69() {
+        // Assign result from 'void' function
+        compileErrors("test/test69.bds", "Cannot cast void to string[]");
+    }
+
+    @Test
+    public void test70() {
+        // Return different type of array
+        compileErrors("test/test70.bds", "Cannot cast A[] to B[]");
+    }
+
+    @Test
+    public void test71_castEmptyListOfObjects() {
+        // Initialize with an empty list of objects
+        compileOk("test/test71.bds");
+    }
+
+    @Test
+    public void test72_castEmptyMapOfObjects() {
+        // Initialize with an empty map of objects
+        compileOk("test/test72.bds");
+    }
+
+    @Test
+    public void test73_plus_minus_typo_string() {
+        // Using '+-' instead of '+=' creates a "This should never happen" error instead of compilation error
+		//		$ bds -v test/test73.bds
+		//		2022/09/07 08:34:05 Verbose mode set
+		//		00:00:00.000	Compile error ExpressionUnaryPlusMinus test/test73.bds:4,3: Cannot cast to 'int' or 'real'. This should never happen!
+		//				java.lang.RuntimeException: Compile error ExpressionUnaryPlusMinus test/test73.bds:4,3: Cannot cast to 'int' or 'real'. This should never happen!
+		//				at org.bds.BdsLog.compileError(BdsLog.java:21)
+		//		at org.bds.BdsLog.compileError(BdsLog.java:14)
+		//		at org.bds.lang.expression.ExpressionUnaryPlusMinus.toAsmUnaryMinus(ExpressionUnaryPlusMinus.java:79)
+		//		at org.bds.lang.expression.ExpressionUnaryPlusMinus.toAsm(ExpressionUnaryPlusMinus.java:53)
+		//		at org.bds.lang.expression.ExpressionBinary.toAsm(ExpressionBinary.java:74)
+		//		at org.bds.lang.expression.ExpressionPlus.toAsm(ExpressionPlus.java:91)
+		//		at org.bds.lang.expression.ExpressionDelegateBinary.toAsm(ExpressionDelegateBinary.java:67)
+		//		at org.bds.lang.statement.StatementExpr.toAsm(StatementExpr.java:31)
+		//		at org.bds.lang.ProgramUnit.toAsm(ProgramUnit.java:127)
+		//		at org.bds.run.BdsRun.compileAsm(BdsRun.java:165)
+		//		at org.bds.run.BdsRun.compile(BdsRun.java:154)
+		//		at org.bds.run.BdsRun.runCompile(BdsRun.java:532)
+		//		at org.bds.run.BdsRun.run(BdsRun.java:440)
+		//		at org.bds.Bds.run(Bds.java:405)
+		//		at org.bds.Bds.main(Bds.java:56)
+        compileOk("test/test73.bds");
+    }
+
+    @Test
+    public void test74_plus_minus_typo_string() {
+        // Using '+-' instead of '+=' creates a null pointer error instead of compilation error
+		//		$ bds -v test/test74.bds
+		//		2022/09/07 08:34:10 Verbose mode set
+		//		java.lang.NullPointerException
+		//		at org.bds.lang.expression.ExpressionPlus.toAsm(ExpressionPlus.java:87)
+		//		at org.bds.lang.expression.ExpressionDelegateBinary.toAsm(ExpressionDelegateBinary.java:67)
+		//		at org.bds.lang.statement.StatementExpr.toAsm(StatementExpr.java:31)
+		//		at org.bds.lang.ProgramUnit.toAsm(ProgramUnit.java:127)
+		//		at org.bds.run.BdsRun.compileAsm(BdsRun.java:165)
+		//		at org.bds.run.BdsRun.compile(BdsRun.java:154)
+		//		at org.bds.run.BdsRun.runCompile(BdsRun.java:532)
+		//		at org.bds.run.BdsRun.run(BdsRun.java:440)
+		//		at org.bds.Bds.run(Bds.java:405)
+		//		at org.bds.Bds.main(Bds.java:56)
+        compileOk("test/test73.bds");
+    }
+
 }

--- a/src/org/bds/test/unit/TestCasesLang.java
+++ b/src/org/bds/test/unit/TestCasesLang.java
@@ -443,7 +443,6 @@ public class TestCasesLang extends TestCasesBase {
 		//		at org.bds.run.BdsRun.run(BdsRun.java:440)
 		//		at org.bds.Bds.run(Bds.java:405)
 		//		at org.bds.Bds.main(Bds.java:56)
-        verbose = true;
         compileErrors("test/test73.bds", "Unary expression '-' unknown return type");
     }
 
@@ -463,7 +462,7 @@ public class TestCasesLang extends TestCasesBase {
 		//		at org.bds.run.BdsRun.run(BdsRun.java:440)
 		//		at org.bds.Bds.run(Bds.java:405)
 		//		at org.bds.Bds.main(Bds.java:56)
-        compileOk("test/test73.bds");
+        compileErrors("test/test74.bds", "Unary expression '-' unknown return type");
     }
 
 }

--- a/src/org/bds/test/unit/TestCasesLang.java
+++ b/src/org/bds/test/unit/TestCasesLang.java
@@ -465,4 +465,10 @@ public class TestCasesLang extends TestCasesBase {
         compileErrors("test/test74.bds", "Unary expression '-' unknown return type");
     }
 
+    @Test
+    public void test75_plus_minus_typo_string() {
+        // Using '+-' instead of '+=' creates a null pointer error instead of compilation error
+        compileErrors("test/test75.bds", "Unary expression '-' unknown return type");
+    }
+
 }

--- a/test/graph_08.in.txt
+++ b/test/graph_08.in.txt
@@ -1,1 +1,1 @@
-Fri Jun 24 10:02:06 CEST 2022
+Wed Sep  7 18:08:57 EDT 2022

--- a/test/graph_09.in.txt
+++ b/test/graph_09.in.txt
@@ -1,1 +1,1 @@
-Fri Jun 24 10:02:10 CEST 2022
+Wed Sep  7 18:09:01 EDT 2022

--- a/test/graph_10.in1.txt
+++ b/test/graph_10.in1.txt
@@ -1,1 +1,1 @@
-Fri Jun 24 10:02:10 CEST 2022
+Wed Sep  7 18:09:01 EDT 2022

--- a/test/graph_10.in2.txt
+++ b/test/graph_10.in2.txt
@@ -1,1 +1,1 @@
-Fri Jun 24 10:02:10 CEST 2022
+Wed Sep  7 18:09:01 EDT 2022

--- a/test/graph_10.mid22.txt
+++ b/test/graph_10.mid22.txt
@@ -1,1 +1,1 @@
-Fri Jun 24 10:02:11 CEST 2022
+Wed Sep  7 18:09:02 EDT 2022

--- a/test/run_104.in
+++ b/test/run_104.in
@@ -1,1 +1,1 @@
-Fri Jun 24 10:00:13 CEST 2022
+Wed Sep  7 18:07:06 EDT 2022

--- a/test/run_105.in
+++ b/test/run_105.in
@@ -1,1 +1,1 @@
-Fri Jun 24 10:00:14 CEST 2022
+Wed Sep  7 18:07:07 EDT 2022

--- a/test/test73.bds
+++ b/test/test73.bds
@@ -1,0 +1,5 @@
+#!/usr/bin/env bds
+
+l := 'a'
+l +- 'c'	# Note the typo, it says '+-' instead of '+='
+println "l = $l"

--- a/test/test74.bds
+++ b/test/test74.bds
@@ -1,0 +1,5 @@
+#!/usr/bin/env bds
+
+l := ['a', 'b']
+l +- 'c'	# Note the typo, it says '+-' instead of '+='
+println "l = $l"

--- a/test/test75.bds
+++ b/test/test75.bds
@@ -1,0 +1,5 @@
+#!/usr/bin/env bds
+
+l := ['a', 'b']
+l +- ['c']	# Note the typo, it says '+-' instead of '+='
+println "l = $l"

--- a/test/z.bds
+++ b/test/z.bds
@@ -1,17 +1,6 @@
 #!/usr/bin/env bds
 
-for(int i=0 ; i < 10 ; i++ ) {
-    in := "/tmp/in.$i\.txt"
-    out	:= "/tmp/out1.$i\.txt"
-    out2 := "/tmp/out2.$i\.txt"
-
-    in.write('0123456789')
-
-    task([out, out2] <- in, taskName := "MyTask_$i", cpus := 2) {
-        sys echo "processing file '$in'"
-        sys sleep $i
-        sys date > $out
-        sys date > $out2
-    }
-}
-
+# l := ['a', 'b']
+l := 'a'
+l +- 'c'
+println "l = $l"


### PR DESCRIPTION
Fixing "null pointer" error when parsing incorrect code:

```
l := 'a'
l +- 'c'	# Note the typo, it says '+-' instead of '+='
```

Fixed, test cases added.