### PR TITLE
Escape html special characters in reports

### DIFF
--- a/src/org/bds/report/RTemplate.java
+++ b/src/org/bds/report/RTemplate.java
@@ -181,6 +181,7 @@ public class RTemplate {
 			String value = keyValues.get(key).get(idx);
 
 			sb.append(lineParts.get(i));
+			// sb.append(value.replace("<", "&lt;").replace(">", "&gt;"));
 			sb.append(value);
 		}
 

--- a/src/org/bds/report/RTemplate.java
+++ b/src/org/bds/report/RTemplate.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import org.bds.util.AutoHashMap;
 import org.bds.util.Gpr;
@@ -37,6 +38,7 @@ public class RTemplate {
 	@SuppressWarnings("rawtypes")
 	Class baseClass;
 	String resourceName;
+	Boolean shouldEscapeHTML;
 	AutoHashMap<String, List<String>> keyValues;
 
 	@SuppressWarnings("rawtypes")
@@ -44,6 +46,7 @@ public class RTemplate {
 		this.outFile = outFile;
 		this.baseClass = baseClass;
 		this.resourceName = resourceName;
+		this.shouldEscapeHTML = outFile.endsWith(".html");
 		keyValues = new AutoHashMap<String, List<String>>(new ArrayList<String>());
 	}
 
@@ -181,8 +184,8 @@ public class RTemplate {
 			String value = keyValues.get(key).get(idx);
 
 			sb.append(lineParts.get(i));
-			// sb.append(value.replace("<", "&lt;").replace(">", "&gt;"));
-			sb.append(value);
+			if (shouldEscapeHTML) sb.append(StringEscapeUtils.escapeHtml4(value));
+			else sb.append(value);
 		}
 
 		// Add last part

--- a/src/org/bds/test/unit/TestCasesReport.java
+++ b/src/org/bds/test/unit/TestCasesReport.java
@@ -22,4 +22,17 @@ public class TestCasesReport extends TestCasesBase {
         Assert.assertTrue("Yaml report doesn't have the expected 'tasksFailed' entry", report.indexOf("tasksFailed: 0") > 0);
     }
 
+    @Test
+    public void test02_report_should_escape_html_chars_in_html_report() {
+        String report = runAndGetReport(dir + "report_02.bds", false);
+        Assert.assertTrue("HTML report doesn't escape html chars", report.indexOf("echo '<html>'") < 0);
+        Assert.assertTrue("HTML report doesn't escape html chars", report.indexOf("echo '&gt;html&lt;'") > 0);
+    }
+
+    @Test
+    public void test02_report_should_escape_html_chars_in_yaml_report() {
+        String report = runAndGetReport(dir + "report_02.bds", true);
+        Assert.assertTrue("YAML report does escape html chars", report.indexOf("echo '<html>'") > 0);
+    }
+
 }

--- a/src/org/bds/test/unit/TestCasesReport.java
+++ b/src/org/bds/test/unit/TestCasesReport.java
@@ -26,11 +26,11 @@ public class TestCasesReport extends TestCasesBase {
     public void test02_report_should_escape_html_chars_in_html_report() {
         String report = runAndGetReport(dir + "report_02.bds", false);
         Assert.assertTrue("HTML report doesn't escape html chars", report.indexOf("echo '<html>'") < 0);
-        Assert.assertTrue("HTML report doesn't escape html chars", report.indexOf("echo '&gt;html&lt;'") > 0);
+        Assert.assertTrue("HTML report doesn't escape html chars", report.indexOf("echo '&lt;html&gt;'") > 0);
     }
 
     @Test
-    public void test02_report_should_escape_html_chars_in_yaml_report() {
+    public void test02_report_should_not_escape_html_chars_in_yaml_report() {
         String report = runAndGetReport(dir + "report_02.bds", true);
         Assert.assertTrue("YAML report does escape html chars", report.indexOf("echo '<html>'") > 0);
     }

--- a/test/unit/report/report_02.bds
+++ b/test/unit/report/report_02.bds
@@ -1,0 +1,4 @@
+
+task echo '<html>'
+wait
+


### PR DESCRIPTION
This PR introduces escaping HTML special characters in report generation. Unit tests had been added to cover this. special characters are not escaped in case of yaml report